### PR TITLE
manifest tag must be the parent of uses-permission

### DIFF
--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest 
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <application>
-        <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-        <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <application>     
         <activity android:name="com.tangxiaolv.telegramgallery.GalleryActivity" />
     </application>
 </manifest>


### PR DESCRIPTION
manifest tag must be the parent of uses-permission tag, unable to create a release version of the APK if this is not the case.
Related to issue https://github.com/bradmartin/nativescript-telegram-image-picker/issues/3